### PR TITLE
KAFKA-3708: Better exception handling in Kafka Streams

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.ConsumerRecordTimestampExtractor;
 import org.apache.kafka.streams.processor.DefaultPartitionGrouper;
 import org.apache.kafka.streams.processor.internals.StreamPartitionAssignor;
@@ -412,17 +413,23 @@ public class StreamsConfig extends AbstractConfig {
     }
 
     public Serde keySerde() {
-        Serde<?> serde = getConfiguredInstance(StreamsConfig.KEY_SERDE_CLASS_CONFIG, Serde.class);
-        serde.configure(originals(), true);
-
-        return serde;
+        try {
+            Serde<?> serde = getConfiguredInstance(StreamsConfig.KEY_SERDE_CLASS_CONFIG, Serde.class);
+            serde.configure(originals(), true);
+            return serde;
+        } catch (Exception e) {
+            throw new StreamsException(String.format("Failed to configure key serde %s", get(StreamsConfig.KEY_SERDE_CLASS_CONFIG)), e);
+        }
     }
 
     public Serde valueSerde() {
-        Serde<?> serde = getConfiguredInstance(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, Serde.class);
-        serde.configure(originals(), false);
-
-        return serde;
+        try {
+            Serde<?> serde = getConfiguredInstance(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, Serde.class);
+            serde.configure(originals(), false);
+            return serde;
+        } catch (Exception e) {
+            throw new StreamsException(String.format("Failed to configure value serde %s", get(StreamsConfig.VALUE_SERDE_CLASS_CONFIG)), e);
+        }
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.streams.processor.internals;
 
+import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
 
@@ -62,11 +63,19 @@ public class ProcessorNode<K, V> {
     }
 
     public void init(ProcessorContext context) {
-        processor.init(context);
+        try {
+            processor.init(context);
+        } catch (Exception e) {
+            throw new StreamsException(String.format("failed to initialize processor %s", name), e);
+        }
     }
 
     public void close() {
-        processor.close();
+        try {
+            processor.close();
+        } catch (Exception e) {
+            throw new StreamsException(String.format("failed to close processor %s", name), e);
+        }
     }
 
     public void process(final K key, final V value) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -21,6 +21,8 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.StateRestoreCallback;
 import org.apache.kafka.streams.processor.StateStore;
@@ -158,7 +160,12 @@ public class ProcessorStateManager {
                 // ignore
             }
 
-            List<PartitionInfo> partitionInfos = restoreConsumer.partitionsFor(topic);
+            List<PartitionInfo> partitionInfos = null;
+            try {
+                partitionInfos = restoreConsumer.partitionsFor(topic);
+            } catch (TimeoutException e) {
+                throw new StreamsException(String.format("task [%s] Could not find partition info for topic: %s", taskId, topic));
+            }
             if (partitionInfos == null) {
                 throw new StreamsException(String.format("task [%s] Could not find partition info for topic: %s", taskId, topic));
             }
@@ -190,7 +197,7 @@ public class ProcessorStateManager {
 
         // subscribe to the store's partition
         if (!restoreConsumer.subscription().isEmpty()) {
-            throw new IllegalStateException(String.format("task [%s]  Restore consumer should have not subscribed to any partitions beforehand", taskId));
+            throw new IllegalStateException(String.format("task [%s] Restore consumer should have not subscribed to any partitions beforehand", taskId));
         }
         TopicPartition storePartition = new TopicPartition(topicName, getPartition(topicName));
         restoreConsumer.assign(Collections.singletonList(storePartition));
@@ -268,7 +275,11 @@ public class ProcessorStateManager {
         int count = 0;
         for (ConsumerRecord<byte[], byte[]> record : records) {
             if (record.offset() < limit) {
-                restoreCallback.restore(record.key(), record.value());
+                try {
+                    restoreCallback.restore(record.key(), record.value());
+                } catch (Exception e) {
+                    throw new ProcessorStateException(String.format("task [%s] exception caught while trying to restore state from %s", taskId, storePartition), e);
+                }
                 lastOffset = record.offset();
             } else {
                 if (remainingRecords == null)
@@ -305,7 +316,11 @@ public class ProcessorStateManager {
                 if (processorNode != null) {
                     context.setCurrentNode(processorNode);
                 }
-                store.flush();
+                try {
+                    store.flush();
+                } catch (Exception e) {
+                    throw new ProcessorStateException(String.format("task [%s] Failed to flush state store %s", taskId, store.name()), e);
+                }
             }
         }
     }
@@ -321,8 +336,12 @@ public class ProcessorStateManager {
                 log.debug("task [{}] Closing stores.", taskId);
                 for (Map.Entry<String, StateStore> entry : stores.entrySet()) {
                     log.debug("task [{}} Closing storage engine {}", taskId, entry.getKey());
-                    entry.getValue().flush();
-                    entry.getValue().close();
+                    try {
+                        entry.getValue().flush();
+                        entry.getValue().close();
+                    } catch (Exception e) {
+                        throw new ProcessorStateException(String.format("task [%s] Failed to close state store %s", taskId, entry.getKey()), e);
+                    }
                 }
 
                 Map<TopicPartition, Long> checkpointOffsets = new HashMap<>();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -313,9 +313,6 @@ public class StreamThread extends Thread {
         boolean requiresPoll = true;
         boolean polledRecords = false;
 
-        // TODO: this can be removed after KIP-62
-        long lastPoll = 0L;
-
         if (topicPattern != null) {
             consumer.subscribe(topicPattern, rebalanceListener);
         } else {
@@ -332,7 +329,6 @@ public class StreamThread extends Thread {
                 boolean longPoll = totalNumBuffered == 0;
 
                 ConsumerRecords<byte[], byte[]> records = consumer.poll(longPoll ? this.pollTimeMs : 0);
-                lastPoll = time.milliseconds();
 
                 if (rebalanceException != null)
                     throw new StreamsException(String.format("stream-thread [%s] Failed to rebalance", this.getName()), rebalanceException);
@@ -372,11 +368,6 @@ public class StreamThread extends Thread {
                         if (task.commitNeeded())
                             commitOne(task);
                     }
-
-                    // if pollTimeMs has passed since the last poll, we poll to respond to a possible rebalance
-                    // even when we paused all partitions.
-                    if (lastPoll + this.pollTimeMs < this.timerStartedMs)
-                        requiresPoll = true;
 
                 } else {
                     // even when no task is assigned, we must poll to get a task.

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
@@ -19,9 +19,12 @@ package org.apache.kafka.streams;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.streams.errors.StreamsException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -172,4 +175,40 @@ public class StreamsConfigTest {
     }
 
 
+
+    @Test(expected = StreamsException.class)
+    public void shouldThrowStreamsExceptionIfKeySerdeConfigFails() throws Exception {
+        props.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, MisconfiguredSerde.class);
+        final StreamsConfig streamsConfig = new StreamsConfig(props);
+        streamsConfig.keySerde();
+    }
+
+    @Test(expected = StreamsException.class)
+    public void shouldThrowStreamsExceptionIfValueSerdeConfigFails() throws Exception {
+        props.put(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, MisconfiguredSerde.class);
+        final StreamsConfig streamsConfig = new StreamsConfig(props);
+        streamsConfig.valueSerde();
+    }
+
+    static class MisconfiguredSerde implements Serde {
+        @Override
+        public void configure(final Map configs, final boolean isKey) {
+            throw new RuntimeException("boom");
+        }
+
+        @Override
+        public void close() {
+
+        }
+
+        @Override
+        public Serializer serializer() {
+            return null;
+        }
+
+        @Override
+        public Deserializer deserializer() {
+            return null;
+        }
+    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.AuthorizationException;
+import org.apache.kafka.common.errors.WakeupException;
+import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.state.internals.ThreadCache;
+import org.apache.kafka.test.TestUtils;
+import org.junit.Test;
+
+import java.util.Collections;
+
+public class AbstractTaskTest {
+
+    @Test(expected = ProcessorStateException.class)
+    public void shouldThrowProcessorStateExceptionOnInitializeOffsetsWhenAuthorizationException() throws Exception {
+        final Consumer consumer = mockConsumer(new AuthorizationException("blah"));
+        final AbstractTask task = createTask(consumer);
+        task.initializeOffsetLimits();
+    }
+
+    @Test(expected = ProcessorStateException.class)
+    public void shouldThrowProcessorStateExceptionOnInitializeOffsetsWhenKafkaException() throws Exception {
+        final Consumer consumer = mockConsumer(new KafkaException("blah"));
+        final AbstractTask task = createTask(consumer);
+        task.initializeOffsetLimits();
+    }
+
+    @Test(expected = WakeupException.class)
+    public void shouldThrowWakeupExceptionOnInitializeOffsetsWhenWakeupException() throws Exception {
+        final Consumer consumer = mockConsumer(new WakeupException());
+        final AbstractTask task = createTask(consumer);
+        task.initializeOffsetLimits();
+    }
+
+    private AbstractTask createTask(final Consumer consumer) {
+        return new AbstractTask(new TaskId(0, 0),
+                                "app",
+                                Collections.singletonList(new TopicPartition("t", 0)),
+                                new ProcessorTopology(Collections.<ProcessorNode>emptyList(),
+                                                      Collections.<String, SourceNode>emptyMap(),
+                                                      Collections.<String, SinkNode>emptyMap(),
+                                                      Collections.<StateStore>emptyList(),
+                                                      Collections.<String, String>emptyMap(),
+                                                      Collections.<StateStore, ProcessorNode>emptyMap()
+                                               ),
+                                consumer,
+                                consumer,
+                                false,
+                                new StateDirectory("app", TestUtils.tempDirectory().getPath()),
+                                new ThreadCache(0)) {
+            @Override
+            public void commit() {
+                // do nothing
+            }
+        };
+    }
+
+    private Consumer mockConsumer(final RuntimeException toThrow) {
+        return new MockConsumer(OffsetResetStrategy.EARLIEST) {
+            @Override
+            public OffsetAndMetadata committed(final TopicPartition partition) {
+                throw toThrow;
+            }
+        };
+    }
+
+}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.processor.Processor;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.junit.Test;
+
+import java.util.Collections;
+
+public class ProcessorNodeTest {
+
+    @SuppressWarnings("unchecked")
+    @Test (expected = StreamsException.class)
+    public void shouldThrowStreamsExceptionIfExceptionCaughtDuringInit() throws Exception {
+        final ProcessorNode node = new ProcessorNode("name", new ExceptionalProcessor(), Collections.emptySet());
+        node.init(null);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test (expected = StreamsException.class)
+    public void shouldThrowStreamsExceptionIfExceptionCaughtDuringClose() throws Exception {
+        final ProcessorNode node = new ProcessorNode("name", new ExceptionalProcessor(), Collections.emptySet());
+        node.close();
+    }
+
+    private static class ExceptionalProcessor implements Processor {
+        @Override
+        public void init(final ProcessorContext context) {
+            throw new RuntimeException();
+        }
+
+        @Override
+        public void process(final Object key, final Object value) {
+            throw new RuntimeException();
+        }
+
+        @Override
+        public void punctuate(final long timestamp) {
+            throw new RuntimeException();
+        }
+
+        @Override
+        public void close() {
+            throw new RuntimeException();
+        }
+    }
+
+}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordCollectorTest.java
@@ -17,15 +17,19 @@
 
 package org.apache.kafka.streams.processor.internals;
 
+import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.clients.producer.internals.DefaultPartitioner;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 import org.junit.Test;
 
@@ -33,6 +37,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
 
@@ -119,4 +125,40 @@ public class RecordCollectorTest {
         assertEquals((Long) 0L, offsets.get(new TopicPartition("topic1", 2)));
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldRetryWhenTimeoutExceptionOccursOnSend() throws Exception {
+        final AtomicInteger attempt = new AtomicInteger(0);
+        RecordCollector collector = new RecordCollector(
+                new MockProducer(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
+                    @Override
+                    public synchronized Future<RecordMetadata> send(final ProducerRecord record, final Callback callback) {
+                        if (attempt.getAndIncrement() == 0) {
+                            throw new TimeoutException();
+                        }
+                        return super.send(record, callback);
+                    }
+                },
+                "test");
+
+        collector.send(new ProducerRecord<>("topic1", "3", "0"), stringSerializer, stringSerializer, streamPartitioner);
+        final Long offset = collector.offsets().get(new TopicPartition("topic1", 0));
+        assertEquals(Long.valueOf(0L), offset);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(expected = StreamsException.class)
+    public void shouldThrowStreamsExceptionAfterMaxAttempts() throws Exception {
+        RecordCollector collector = new RecordCollector(
+                new MockProducer(cluster, true, new DefaultPartitioner(), byteArraySerializer, byteArraySerializer) {
+                    @Override
+                    public synchronized Future<RecordMetadata> send(final ProducerRecord record, final Callback callback) {
+                        throw new TimeoutException();
+                    }
+                },
+                "test");
+
+        collector.send(new ProducerRecord<>("topic1", "3", "0"), stringSerializer, stringSerializer, streamPartitioner);
+
+    }
 }


### PR DESCRIPTION
KafkaExceptions currently thrown from within StreamThread/StreamTask currently bubble up without any additional context. This makes it hard to figure out where something went wrong, i.e, which topic had the serialization exception etc

Author: Damian Guy damian.guy@gmail.com

Reviewers: Guozhang Wang wangguoz@gmail.com

Closes #1819 from dguy/kafka-3708 and squashes the following commits:

d6feaa8 [Damian Guy] address comments
15b89e7 [Damian Guy] merge trunk
6b8a8af [Damian Guy] catch exceptions in various places and throw more informative versions
c86eeda [Damian Guy] fix conflicts
8f37e2c [Damian Guy] add some context to exceptions
