### PR TITLE
HOTFIX: do not call partitioner if num partitions is non-positive

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollector.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollector.java
@@ -73,7 +73,7 @@ public class RecordCollector {
         Integer partition = record.partition();
         if (partition == null && partitioner != null) {
             List<PartitionInfo> partitions = this.producer.partitionsFor(record.topic());
-            if (partitions != null)
+            if (partitions != null && partitions.size() > 0)
                 partition = partitioner.partition(record.key(), record.value(), partitions.size());
         }
 

--- a/streams/src/test/java/org/apache/kafka/test/ProcessorTopologyTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/test/ProcessorTopologyTestDriver.java
@@ -158,7 +158,7 @@ public class ProcessorTopologyTestDriver {
         producer = new MockProducer<byte[], byte[]>(true, bytesSerializer, bytesSerializer) {
             @Override
             public List<PartitionInfo> partitionsFor(String topic) {
-                return Collections.emptyList();
+                return Collections.singletonList(new PartitionInfo(topic, 0, null, null, null));
             }
         };
         restoreStateConsumer = createRestoreConsumer(id, storeNames);


### PR DESCRIPTION
Author: Guozhang Wang wangguoz@gmail.com

Reviewers: Eno Thereska, Damian Guy

Closes #1929 from guozhangwang/KMinor-check-zero-num-partitions and squashes the following commits:

c8edc2d [Guozhang Wang] fix unit test
3127f9c [Guozhang Wang] do not call partitioner if num partitions is non-positive
